### PR TITLE
Revert "Bump Oracle.ManagedDataAccess.Core from 2.19.230 to 2.19.250 …

### DIFF
--- a/PCAxis.Sql/PCAxis.Sql.csproj
+++ b/PCAxis.Sql/PCAxis.Sql.csproj
@@ -46,7 +46,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Oracle.ManagedDataAccess.Core" Version="2.19.250" />
+    <PackageReference Include="Oracle.ManagedDataAccess.Core" Version="2.19.230" />
     <PackageReference Include="PCAxis.Core" Version="1.2.4" />
     <PackageReference Include="System.Security.Cryptography.Xml" Version="7.0.1" />
   </ItemGroup>


### PR DESCRIPTION
This patch upgrade was failing but was still merged automatically. I have changed the repo settings so this will no longer be a problem.