### PR TITLE
Fix parameter collection reinitialization in repository classes

### DIFF
--- a/PCAxis.Sql/Repositories/GroupingRepositoryStatic.cs
+++ b/PCAxis.Sql/Repositories/GroupingRepositoryStatic.cs
@@ -57,6 +57,8 @@ namespace PCAxis.Sql.Repositories
             parameters[0] = cmd.GetStringParameter("aGrouping", groupingId);
 
             var groupingDS = cmd.ExecuteSelect(sqlGrouping, parameters);
+            parameters = new System.Data.Common.DbParameter[1];
+            parameters[0] = cmd.GetStringParameter("aGrouping", groupingId);
             var valuesDS = cmd.ExecuteSelect(sqlValues, parameters);
 
             DataSet extraLangsDS = String.IsNullOrEmpty(sqlGroupingExistsInLang) ? null : cmd.ExecuteSelect(sqlGroupingExistsInLang, parameters);

--- a/PCAxis.Sql/Repositories/ValueSetRepositoryStatic.cs
+++ b/PCAxis.Sql/Repositories/ValueSetRepositoryStatic.cs
@@ -57,6 +57,10 @@ namespace PCAxis.Sql.Repositories
             parameters[0] = cmd.GetStringParameter("aValueSet", valuesetId);
 
             var valuesetDS = cmd.ExecuteSelect(sqlValueset, parameters);
+
+            parameters = new System.Data.Common.DbParameter[1];
+            parameters[0] = cmd.GetStringParameter("aValueSet", valuesetId);
+
             var valuesDS = cmd.ExecuteSelect(sqlValues, parameters);
 
             DataSet extraLangsDS = String.IsNullOrEmpty(sqlValuesetExistsInLang) ? null : cmd.ExecuteSelect(sqlValuesetExistsInLang, parameters);


### PR DESCRIPTION
Reinitialize the `parameters` array in `GroupingRepositoryStatic.cs` and `ValueSetRepositoryStatic.cs` before executing a second SQL query. This ensures that the parameters collection is not used in the second query since that causes a exception.