### PR TITLE
Api2: Add  get list of  tables  publised between to datetimes

### DIFF
--- a/ManualTests/TablesPublishedTest.cs
+++ b/ManualTests/TablesPublishedTest.cs
@@ -1,0 +1,47 @@
+using PCAxis.Sql.ApiUtils;
+
+namespace ManualTests
+{
+    [Ignore]
+    [TestClass]
+    public class TablesPublishTest
+    {
+        private readonly DateTime dt_2025_05_24;
+        private readonly DateTime dt_2025_05_25;
+
+        private readonly DateTime dt_empty;
+
+        public TablesPublishTest()
+        {
+            dt_2025_05_24 = new DateTime(2025, 5, 24, 8, 0, 0, DateTimeKind.Local);
+            dt_2025_05_25 = new DateTime(2025, 5, 25, 8, 0, 0, DateTimeKind.Local);
+            dt_empty = new DateTime(2025, 5, 25, 7, 0, 0, DateTimeKind.Local);
+        }
+
+        [TestMethod]
+        public void TestTablesPublishNormal()
+        {
+            List<string> expected_data = new List<string> { "07888", "10701", "10729", "10738", "10745", "10746", "10748", "10749", "11018" };
+            List<string> actual_data = ApiUtilStatic.GetTablesPublishedBetween(dt_2025_05_24, dt_2025_05_25);
+            Assert.IsNotNull(actual_data);
+            CollectionAssert.AreEquivalent(expected_data, actual_data);
+        }
+
+        [TestMethod]
+        public void TestTablesPublishEmptyl()
+        {
+            List<string> expected_data = new List<string>();
+            List<string> actual_data = ApiUtilStatic.GetTablesPublishedBetween(dt_empty, dt_empty);
+            Assert.IsNotNull(actual_data);
+            CollectionAssert.AreEquivalent(expected_data, actual_data);
+        }
+
+        [TestMethod]
+        public void TestTablesPublish_FromAfterTo_ThrowsArgumentException()
+        {
+            var exception = Assert.ThrowsExactly<ArgumentException>(() => ApiUtilStatic.GetTablesPublishedBetween(dt_2025_05_25, dt_2025_05_24));
+            StringAssert.StartsWith(exception.Message, "'from' date cannot be later than 'to' date.");
+        }
+
+    }
+}

--- a/PCAxis.Sql/ApiUtils/ApiUtilStatic.cs
+++ b/PCAxis.Sql/ApiUtils/ApiUtilStatic.cs
@@ -75,13 +75,21 @@ namespace PCAxis.Sql.ApiUtils
         }
 
 
+        /// <summary> The intended for the (Lucene) indexer in the IndexDatabase endpoint. 
+        /// Returns a list of maintable.tableid for  tables where content.published is in the intervall [from,to]
+        /// TODO should we restrict to DB.MainTable.TableStatusCol.Is("'A'") + " AND " + DB.MainTable.PresCategoryCol.Is("'O'") ? 
+        /// </summary>
+        /// <param name="from">Earliest. MinDate. Inclusive</param>
+        /// <param name="to">Lastest. MaxDate. Inclusive</param>
+        /// <returns>a list of maintable.tableid which may be empty</returns>
+        public static List<string> GetTablesPublishedBetween(DateTime from, DateTime to)
+        {
+            if (from > to)
+                throw new ArgumentException("'from' date cannot be later than 'to' date.");
 
-        //TODO:
-        //For use by indexer. IndexDatabase endpoint v2
-        // liste med tabellid og publ dato
-        // tabellid er unik, mens publ dato er det vi spørr mot
+            return TablesPublishedBetweenRepositoryStatic.GetTablesPublishedBetween(from, to);
+        }
 
-        //List<table_id> get_tables_published_since(DateTime)but_not_in_future
 
         private static string ValidateLangCodeString(string input)
         {

--- a/PCAxis.Sql/QueryLib_21/Queries.cs
+++ b/PCAxis.Sql/QueryLib_21/Queries.cs
@@ -180,6 +180,10 @@ namespace PCAxis.Sql.QueryLib_21
                             {_db.MenuSelection.LevelNoCol.Id()} NOT IN (SELECT {_db.MetaAdm.ValueCol} FROM {_db.MetaAdm.GetNameAndAlias()} WHERE upper({_db.MetaAdm.PropertyCol.Id()}) = 'MENULEVELS')";
             }
         }
+        internal override string GetTablesPublishedSinceQuery(PxSqlCommand sqlCommand)
+        {
+            throw new NotImplementedException();
+        }
     }
 
     public static class TableLangFixer

--- a/PCAxis.Sql/QueryLib_22/Queries.cs
+++ b/PCAxis.Sql/QueryLib_22/Queries.cs
@@ -252,6 +252,14 @@ namespace PCAxis.Sql.QueryLib_22
                            {_db.MenuSelection.LevelNoCol.Id()} NOT IN (SELECT {_db.MetaAdm.ValueCol} FROM {_db.MetaAdm.GetNameAndAlias()} WHERE upper({_db.MetaAdm.PropertyCol.Id()}) = 'MENULEVELS')";
             }
         }
+
+        internal override string GetTablesPublishedSinceQuery(PxSqlCommand sqlCommand)
+        {
+            return $@"SELECT  DISTINCT {_db.MainTable.TableIdCol.ForSelect()} FROM {_db.MainTable.GetNameAndAlias()} 
+                      JOIN {_db.Contents.GetNameAndAlias()} ON {_db.Contents.MainTableCol.Id()} = {_db.MainTable.MainTableCol.Id()}
+                        WHERE {_db.Contents.PublishedCol.Id()} >=  {sqlCommand.GetParameterRef("aFrom")}
+                          AND {_db.Contents.PublishedCol.Id()} <=  {sqlCommand.GetParameterRef("aTo")} ";
+        }
     }
 
 

--- a/PCAxis.Sql/QueryLib_23/Queries.cs
+++ b/PCAxis.Sql/QueryLib_23/Queries.cs
@@ -259,6 +259,13 @@ namespace PCAxis.Sql.QueryLib_23
             }
 
         }
+        internal override string GetTablesPublishedSinceQuery(PxSqlCommand sqlCommand)
+        {
+            return $@"SELECT  DISTINCT {_db.MainTable.TableIdCol.ForSelect()} FROM {_db.MainTable.GetNameAndAlias()} 
+                      JOIN {_db.Contents.GetNameAndAlias()} ON {_db.Contents.MainTableCol.Id()} = {_db.MainTable.MainTableCol.Id()}
+                        WHERE {_db.Contents.PublishedCol.Id()} >=  {sqlCommand.GetParameterRef("aFrom")}
+                          AND {_db.Contents.PublishedCol.Id()} <=  {sqlCommand.GetParameterRef("aTo")} ";
+        }
     }
 
     public static class TableLangFixer

--- a/PCAxis.Sql/QueryLib_24/Queries.cs
+++ b/PCAxis.Sql/QueryLib_24/Queries.cs
@@ -258,6 +258,15 @@ namespace PCAxis.Sql.QueryLib_24
             }
 
         }
+
+        internal override string GetTablesPublishedSinceQuery(PxSqlCommand sqlCommand)
+        {
+            return $@"SELECT  DISTINCT {_db.MainTable.TableIdCol.ForSelect()} FROM {_db.MainTable.GetNameAndAlias()} 
+                      JOIN {_db.Contents.GetNameAndAlias()} ON {_db.Contents.MainTableCol.Id()} = {_db.MainTable.MainTableCol.Id()}
+                        WHERE {_db.Contents.PublishedCol.Id()} >=  {sqlCommand.GetParameterRef("aFrom")}
+                          AND {_db.Contents.PublishedCol.Id()} <=  {sqlCommand.GetParameterRef("aTo")} ";
+        }
+
     }
 
     public static class TableLangFixer

--- a/PCAxis.Sql/Repositories/AbstractQueries.cs
+++ b/PCAxis.Sql/Repositories/AbstractQueries.cs
@@ -31,6 +31,8 @@ namespace PCAxis.Sql.Repositories
 
         internal abstract string GetMenuLookupFolderQuery(string lang);
 
+        internal abstract string GetTablesPublishedSinceQuery(PxSqlCommand sqlCommand);
+
         internal static AbstractQueries GetSqlqueries(SqlDbConfig config)
         {
             if (config.MetaModel.Equals("2.1"))

--- a/PCAxis.Sql/Repositories/TablesPublishedBetweenRepositoryStatic.cs
+++ b/PCAxis.Sql/Repositories/TablesPublishedBetweenRepositoryStatic.cs
@@ -1,0 +1,72 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Data.Common;
+
+using PCAxis.Sql.DbClient;
+using PCAxis.Sql.DbConfig;
+
+namespace PCAxis.Sql.Repositories
+{
+    internal static class TablesPublishedBetweenRepositoryStatic
+    {
+
+        private static readonly string TheSql;
+
+        static TablesPublishedBetweenRepositoryStatic()
+        {
+            var config = SqlDbConfigsStatic.DefaultDatabase;
+            AbstractQueries queries = AbstractQueries.GetSqlqueries(config);
+
+            InfoForDbConnection info = config.GetInfoForDbConnection(config.GetDefaultConnString());
+            var sqlCommand = new PxSqlCommandForTempTables(info.DataBaseType, info.DataProvider, info.ConnectionString);
+
+            TheSql = queries.GetTablesPublishedSinceQuery(sqlCommand);
+        }
+
+
+        internal static List<string> GetTablesPublishedBetween(DateTime from, DateTime to)
+        {
+            List<string> UrlTableIds = new List<string>();
+
+            var config = SqlDbConfigsStatic.DefaultDatabase;
+            InfoForDbConnection info = config.GetInfoForDbConnection(config.GetDefaultConnString());
+
+            var cmd = new PxSqlCommandForTempTables(info.DataBaseType, info.DataProvider, info.ConnectionString);
+            DbParameter[] parameters = GetParameters(from, to, cmd);
+            var dataSet = cmd.ExecuteSelect(TheSql, parameters);
+
+            foreach (DataRow row in dataSet.Tables[0].Rows)
+            {
+                string tableId = row[0].ToString();
+                if (string.IsNullOrEmpty(tableId))
+                {
+                    throw new InvalidOperationException("Cannot read from database: value in row[0] IsNullOrEmpty.");
+                }
+                UrlTableIds.Add(tableId);
+            }
+
+            return UrlTableIds;
+        }
+
+        private static DbParameter[] GetParameters(DateTime from, DateTime to, PxSqlCommandForTempTables cmd)
+        {
+            System.Data.Common.DbParameter[] parameters = new System.Data.Common.DbParameter[2];
+            parameters[0] = cmd.GetDateParameter("aFrom", from);
+            parameters[1] = cmd.GetDateParameter("aTo", to);
+            return parameters;
+        }
+
+
+    }
+
+}
+
+
+
+
+
+
+
+
+

--- a/PCAxis.Sql/SqlClient/PxSqlCommand.cs
+++ b/PCAxis.Sql/SqlClient/PxSqlCommand.cs
@@ -212,6 +212,19 @@ namespace PCAxis.Sql.DbClient
         }
 
         /// <summary>
+        /// Returns a DbParameter with type= DateTime and  parameterName and parameterValue as given.
+        /// </summary>
+        public DbParameter GetDateParameter(string parameterName, DateTime parameterValue)
+        {
+            DbParameter myOut = myDbVendor.GetEmptyDbParameter();
+            myOut.DbType = DbType.DateTime;
+            myOut.ParameterName = parameterName;
+            myOut.Value = parameterValue;
+            return myOut;
+        }
+
+
+        /// <summary>
         /// The reference to a parameter, e.g. @maintable,:maintable or just ? depending on your db
         /// </summary>
         /// <param name="propertyName">The "base" e.g. maintable</param>


### PR DESCRIPTION
 that is, a list of maintable.tableid for tables where content.published is in an intervall.
So that the (lunece) indexer can do an update for just those tables.  